### PR TITLE
画像を複数枚登録/スライドが被らないように表示（失敗）

### DIFF
--- a/app/javascript/custom/sidebar.js
+++ b/app/javascript/custom/sidebar.js
@@ -39,3 +39,28 @@ document.addEventListener('DOMContentLoaded', function () {
 		})
 	})
 })
+
+document.addEventListener("DOMContentLoaded", function() {
+	const fileInput = document.getElementById("listImage");
+	const previewContainer = document.createElement("div");
+	fileInput.parentNode.appendChild(previewContainer);
+  
+	fileInput.addEventListener("change", function() {
+	  previewContainer.innerHTML = ""; // 以前のプレビューをクリア
+	  const files = fileInput.files;
+  
+	  Array.from(files).forEach(file => {
+		const reader = new FileReader();
+		reader.onload = function(e) {
+		  const img = document.createElement("img");
+		  img.src = e.target.result;
+		  img.className = "img-fluid mt-2";
+		  img.style.maxWidth = "150px";
+		  img.style.marginRight = "10px";
+		  previewContainer.appendChild(img);
+		};
+		reader.readAsDataURL(file);
+	  });
+	});
+  });
+  

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,10 +11,10 @@
   </head>
   <body>
     <%= render 'shared/icons' %>
-    <main class="d-flex flex-nowrap">
-      <nav class="d-flex flex-column flex-shrink-0 p-3" style="width: 280px;">
+    <main class="d-flex flex-nowrap" style="position: relative;">
+      <nav class="d-flex flex-column flex-shrink-0 p-3" style="width: 280px; position: relative; z-index: 1100;">
         <a href="/" class="d-flex align-items-center mb-3 mb-md-0 me-md-auto text-decoration-none">
-          <span class="fs-4">Title</span>
+          <span class="fs-4">Jouney Junction</span>
         </a>
         <hr>
         <ul class="nav nav-pills flex-column mb-auto">
@@ -53,9 +53,9 @@
           <%= link_to "ログイン", login_path, class: "btn btn-primary" %>
         <% end %>
       </nav>
+      <%= render partial: "shared/slide" %>
       <%= yield %>
     </main>
-    <%= render partial: "shared/slide" %>
   </body>
   <% flash.each do |message_type, message| %>
     <%= content_tag(:div, message, class: "flash alert alert-#{message_type} position-fixed bottom-0 end-0 me-3") %>

--- a/app/views/shared/_list_form.html.erb
+++ b/app/views/shared/_list_form.html.erb
@@ -22,7 +22,7 @@
       </div>
       <div class="mb-3">
         <label for="listImage" class="form-label">写真</label>
-        <div><input type="file" class="form-control" id="listImage"></div>
+        <div><input type="file" class="form-control" id="listImage" multiple></div>
       </div>
       <div class="mb-3">
         <button type="submit" class="btn btn-primary">投稿</button>


### PR DESCRIPTION
・概要
　・画像を複数枚登録できるようにしました。また、登録した画像のプレビュー表示を見れるようにしました。
　・スライドする時、元々あるnavバーに被らないようにスライドする方法を考えていますが、まだやり方が分からないです。
　
・変更部分の注意点
　・スライドをかぶらないようにするため、application.html.erbのスライドバーを出す部分を変更しました。
　　（結果的には被らないような表示にはできていません。）
　・画像のプレビュー表示をするため、jsファイルを変更しました。